### PR TITLE
Add how to run

### DIFF
--- a/app/assets/javascripts/components/Office.js.jsx
+++ b/app/assets/javascripts/components/Office.js.jsx
@@ -12,7 +12,7 @@ class Office extends React.Component {
         <p>
           Incumbent: <a href={legislator.website} target="_blank">{legislator.title} {legislator.full_name}</a>
         </p>
-        <p>Here's some organizations that may be able to help you run:</p>
+        <p>Here's some resources that may be able to help you run:</p>
         <ul>
           {organizations.map((org) => {
                                       return(

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,17 +15,6 @@ ActiveRecord::Schema.define(version: 20170517225805) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "congress_members", force: :cascade do |t|
-    t.string   "name",       null: false
-    t.string   "state",      null: false
-    t.integer  "district"
-    t.string   "website"
-    t.string   "end",        null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string   "title"
-  end
-
   create_table "resources", force: :cascade do |t|
     t.string   "name"
     t.string   "link"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,15 +49,15 @@ def find_senate_terms
   wa_senate_term_ends
 end
 
+how_to_run_resource = Resource.create(name: "How to Run for this Office", link: "https://www.sos.wa.gov/_assets/elections/candidates/State%20Candidates%20Guide%202017.pdf")
 dem_resource = Resource.create(name: "Washington State Democratic Party", link: "http://www.wa-democrats.org/")
 rep_resource = Resource.create(name: "Washington State Republican Party", link: "https://wsrp.org/")
-how_to_run_resource = Resource.create(name: "How to Run", link: "https://www.sos.wa.gov/_assets/elections/candidates/State%20Candidates%20Guide%202017.pdf")
 
 49.times do |i|
   state_house_district = StateDistrict.create(state: "WA", name: "State House District #{i + 1}")
-  state_house_district.resources << dem_resource << rep_resource << how_to_run_resource
+  state_house_district.resources << how_to_run_resource << dem_resource << rep_resource
   state_senate_district = StateDistrict.create(state: "WA", name: "State Senate District #{i + 1}")
-  state_senate_district.resources << dem_resource << rep_resource << how_to_run_resource
+  state_senate_district.resources << how_to_run_resource << dem_resource << rep_resource
 end
 
 wa_state_reps_link = 'http://leg.wa.gov/house/representatives/pages/default.aspx'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,12 +51,13 @@ end
 
 dem_resource = Resource.create(name: "Washington State Democratic Party", link: "http://www.wa-democrats.org/")
 rep_resource = Resource.create(name: "Washington State Republican Party", link: "https://wsrp.org/")
+how_to_run_resource = Resource.create(name: "How to Run", link: "https://www.sos.wa.gov/_assets/elections/candidates/State%20Candidates%20Guide%202017.pdf")
 
 49.times do |i|
   state_house_district = StateDistrict.create(state: "WA", name: "State House District #{i + 1}")
-  state_house_district.resources << dem_resource << rep_resource
+  state_house_district.resources << dem_resource << rep_resource << how_to_run_resource
   state_senate_district = StateDistrict.create(state: "WA", name: "State Senate District #{i + 1}")
-  state_senate_district.resources << dem_resource << rep_resource
+  state_senate_district.resources << dem_resource << rep_resource << how_to_run_resource
 end
 
 wa_state_reps_link = 'http://leg.wa.gov/house/representatives/pages/default.aspx'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,7 +49,7 @@ def find_senate_terms
   wa_senate_term_ends
 end
 
-how_to_run_resource = Resource.create(name: "How to Run for this Office", link: "https://www.sos.wa.gov/_assets/elections/candidates/State%20Candidates%20Guide%202017.pdf")
+how_to_run_resource = Resource.create(name: "How to File to Run for this Office", link: "https://www.sos.wa.gov/_assets/elections/candidates/State%20Candidates%20Guide%202017.pdf")
 dem_resource = Resource.create(name: "Washington State Democratic Party", link: "http://www.wa-democrats.org/")
 rep_resource = Resource.create(name: "Washington State Republican Party", link: "https://wsrp.org/")
 


### PR DESCRIPTION
Add how to run resources to db seeds and adjust wording on view. 

It appears when I ran migrations  that the schema changed - congress_members was deleted. We weren't using that table anyhow, can't remember when it got added in as I don't see it in a migration.